### PR TITLE
Add multi-metric historical data visualization with D3.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "axum",
  "axum-server",
  "chrono",
+ "lazy_static",
  "minify-html",
  "rustls",
  "rustls-pemfile 1.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ tokio-rustls = "0.24"
 minify-html = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
 tera = "1.20"
+lazy_static = "1.4"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,75 @@
+# Homepage Rust Project
+
+## Project Overview
+A Rust-based homepage server that displays system metrics (CPU usage, temperature, fan speed) via WebSocket connections. Supports both HTTP and HTTPS with optional mutual TLS authentication.
+
+## Architecture
+- **Framework**: Axum web framework with WebSocket support
+- **Metrics**: System information via sysinfo crate
+- **TLS**: rustls for HTTPS and mutual TLS
+- **Deployment**: Kubernetes with dual-stack IPv4/IPv6 support
+
+## Development Commands
+
+### Build & Run
+```bash
+cargo build --release
+cargo run
+```
+
+### Testing
+```bash
+cargo check
+cargo test
+```
+
+### Linting
+```bash
+cargo fmt
+cargo clippy
+```
+
+## Environment Variables
+
+### Protocol Configuration
+- `HTTPS_ONLY`: Set to "true" for HTTPS-only mode (default: false for HTTP)
+
+### TLS Configuration (required when HTTPS_ONLY=true)
+- `TLS_CERT_FILE`: Path to server certificate file
+- `TLS_KEY_FILE`: Path to server private key file
+- `CLIENT_CA_CERT`: Path to client CA certificate (optional, enables mutual TLS)
+
+## Server Behavior
+
+### HTTP Mode (default)
+- Listens on `[::]:8080` (dual-stack IPv4/IPv6)
+- No TLS encryption
+- Suitable for development
+
+### HTTPS Mode
+- Listens on `[::]:6443` (dual-stack IPv4/IPv6)
+- TLS encryption with server certificates
+- Optional mutual TLS if `CLIENT_CA_CERT` is provided
+- Suitable for production
+
+## Endpoints
+- `GET /`: Serves the homepage HTML
+- `GET /ws`: WebSocket endpoint for real-time system metrics
+
+
+## Kubernetes Deployment
+- Located in `kubernetes/homepage/deployment.yaml`
+- Configured for HTTPS with mutual TLS in production
+- Uses secrets for TLS certificates
+- Includes hardware monitoring volume mounts
+
+## System Metrics
+- **CPU Usage**: Global CPU utilization percentage
+- **CPU Temperature**: Hardware temperature (when available)
+- **Fan Speed**: System fan RPM (supports Raspberry Pi and generic hwmon)
+
+## Development Notes
+- Uses dual-stack networking (`[::]:port`) for automatic IPv4/IPv6 support
+- TLS certificates must be in PEM format
+- Hardware monitoring paths are auto-detected (Raspberry Pi and generic hwmon)
+- WebSocket updates every 2 seconds

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -4,13 +4,60 @@ use axum::{
     extract::ws::{WebSocket, WebSocketUpgrade},
     response::Response,
 };
+use chrono::{DateTime, Utc};
 use serde_json::json;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use sysinfo::System;
 use tokio::time::sleep;
 
+#[derive(Clone)]
+struct MetricsDataPoint {
+    timestamp: DateTime<Utc>,
+    cpu_usage: f32,
+    temperature: f32,
+    fan_speed: u32,
+}
+
+type MetricsHistory = Arc<Mutex<VecDeque<MetricsDataPoint>>>;
+
+lazy_static::lazy_static! {
+    static ref METRICS_HISTORY: MetricsHistory = Arc::new(Mutex::new(VecDeque::new()));
+}
+
 pub async fn websocket_handler(ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(handle_websocket)
+}
+
+fn store_metrics_data(cpu_usage: f32, temperature: f32, fan_speed: u32) {
+    let now = Utc::now();
+    let fifteen_minutes_ago = now - chrono::Duration::minutes(15);
+
+    if let Ok(mut history) = METRICS_HISTORY.lock() {
+        history.push_back(MetricsDataPoint {
+            timestamp: now,
+            cpu_usage,
+            temperature,
+            fan_speed,
+        });
+
+        while let Some(front) = history.front() {
+            if front.timestamp < fifteen_minutes_ago {
+                history.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+fn get_metrics_history() -> Vec<MetricsDataPoint> {
+    if let Ok(history) = METRICS_HISTORY.lock() {
+        history.iter().cloned().collect()
+    } else {
+        Vec::new()
+    }
 }
 
 async fn handle_websocket(mut socket: WebSocket) {
@@ -24,11 +71,20 @@ async fn handle_websocket(mut socket: WebSocket) {
         let cpu_temp = read_cpu_temperature().await;
         let fan_speed = read_fan_speed().await;
 
+        store_metrics_data(cpu_usage, cpu_temp, fan_speed);
+        let history = get_metrics_history();
+
         let data = json!({
             "cpuUsage": cpu_usage.round() as u32,
             "cpuTemperature": cpu_temp.round() as u32,
             "fanSpeed": fan_speed,
-            "nodeName": node_name
+            "nodeName": node_name,
+            "metricsHistory": history.iter().map(|point| json!({
+                "timestamp": point.timestamp.timestamp_millis(),
+                "cpuUsage": point.cpu_usage,
+                "temperature": point.temperature,
+                "fanSpeed": point.fan_speed
+            })).collect::<Vec<_>>()
         });
 
         if socket

--- a/templates/index.html
+++ b/templates/index.html
@@ -86,7 +86,34 @@
             }
         }
 
+        /* D3.js graph styling */
+        #cpu-graph svg {
+            font-family: Verdana, sans-serif;
+        }
+        
+        #cpu-graph .axis text {
+            font-size: 11px;
+            fill: #666;
+        }
+        
+        #cpu-graph .axis-label {
+            font-size: 12px;
+            fill: #333;
+        }
+        
+        #cpu-graph .axis path,
+        #cpu-graph .axis line {
+            fill: none;
+            stroke: #ddd;
+            stroke-width: 1;
+        }
+        
+        #cpu-graph .legend-item text {
+            font-family: Verdana, sans-serif;
+        }
+
     </style>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
 <div class="container">
@@ -112,6 +139,7 @@
                 temperature <span id="cpu-temperature">{{ cpu_temperature }}</span>°C, 
                 <a href="https://www.raspberrypi.com/products/active-cooler/" rel="nofollow">fan</a> speed <span id="fan-speed">{{ fan_speed }}</span> RPM.
             </p>
+            <div id="cpu-graph" style="width: 100%; height: 200px; margin: 20px 0; border: 1px solid #ddd; border-radius: 5px; max-width: 600px;"></div>
             <p>
                 I've vibe coded this website using <a href="https://www.anthropic.com/claude-code" rel="nofollow">Claude
                 Code</a> in Rust. The source code of the website is available <a
@@ -127,12 +155,130 @@
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const host = window.location.host;
     const ws = new WebSocket(`${protocol}//${host}/ws`);
+    
+    // CPU Graph setup
+    const container = document.getElementById("cpu-graph");
+    const containerWidth = container.clientWidth;
+    const margin = {top: 20, right: 20, bottom: 10, left: 10};
+    const width = Math.min(containerWidth, 600) - margin.left - margin.right;
+    const height = 200 - margin.top - margin.bottom;
+    
+    const svg = d3.select("#cpu-graph")
+        .append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom)
+        .append("g")
+        .attr("transform", `translate(${margin.left},${margin.top})`);
+    
+    // Scales
+    const xScale = d3.scaleTime()
+        .range([0, width]);
+    
+    const cpuScale = d3.scaleLinear()
+        .domain([0, 100])
+        .range([height, 0]);
+    
+    const tempScale = d3.scaleLinear()
+        .domain([0, 80])
+        .range([height, 0]);
+    
+    const fanScale = d3.scaleLinear()
+        .domain([0, 3000])
+        .range([height, 0]);
+    
+    // Line generators
+    const cpuLine = d3.line()
+        .x(d => xScale(new Date(d.timestamp)))
+        .y(d => cpuScale(d.cpuUsage))
+        .curve(d3.curveMonotoneX);
+    
+    const tempLine = d3.line()
+        .x(d => xScale(new Date(d.timestamp)))
+        .y(d => tempScale(d.temperature))
+        .curve(d3.curveMonotoneX);
+    
+    const fanLine = d3.line()
+        .x(d => xScale(new Date(d.timestamp)))
+        .y(d => fanScale(d.fanSpeed))
+        .curve(d3.curveMonotoneX);
+    
+    
+    
+    // Add paths for each metric
+    const cpuPath = svg.append("path")
+        .attr("fill", "none")
+        .attr("stroke", "#007bff")
+        .attr("stroke-width", 2);
+    
+    const tempPath = svg.append("path")
+        .attr("fill", "none")
+        .attr("stroke", "#dc3545")
+        .attr("stroke-width", 2);
+    
+    const fanPath = svg.append("path")
+        .attr("fill", "none")
+        .attr("stroke", "#28a745")
+        .attr("stroke-width", 2);
+    
+    // Add legend
+    const legend = svg.append("g")
+        .attr("transform", `translate(${width - 100}, 10)`);
+    
+    const legendData = [
+        { name: "CPU %", color: "#007bff" },
+        { name: "Temp °C", color: "#dc3545" },
+        { name: "Fan RPM", color: "#28a745" }
+    ];
+    
+    legend.selectAll(".legend-item")
+        .data(legendData)
+        .enter()
+        .append("g")
+        .attr("class", "legend-item")
+        .attr("transform", (d, i) => `translate(0, ${i * 15})`)
+        .each(function(d) {
+            d3.select(this).append("line")
+                .attr("x1", 0)
+                .attr("x2", 15)
+                .attr("y1", 0)
+                .attr("y2", 0)
+                .attr("stroke", d.color)
+                .attr("stroke-width", 2);
+            
+            d3.select(this).append("text")
+                .attr("x", 20)
+                .attr("y", 0)
+                .attr("dy", "0.35em")
+                .style("font-size", "10px")
+                .style("fill", "#333")
+                .text(d.name);
+        });
+    
+    function updateGraph(data) {
+        if (!data || data.length === 0) return;
+        
+        // Update time domain to show last 15 minutes
+        const now = new Date();
+        const fifteenMinutesAgo = new Date(now.getTime() - 15 * 60 * 1000);
+        xScale.domain([fifteenMinutesAgo, now]);
+        
+        // Update paths for each metric
+        cpuPath.datum(data).attr("d", cpuLine);
+        tempPath.datum(data).attr("d", tempLine);
+        fanPath.datum(data).attr("d", fanLine);
+        
+    }
 
     ws.onmessage = function (event) {
         const data = JSON.parse(event.data);
         document.getElementById("cpu-temperature").textContent = data.cpuTemperature;
         document.getElementById("fan-speed").textContent = data.fanSpeed;
         document.getElementById("cpu-usage").textContent = data.cpuUsage;
+        
+        // Update metrics graph
+        if (data.metricsHistory) {
+            updateGraph(data.metricsHistory);
+        }
     };
 
     ws.onerror = function () {


### PR DESCRIPTION
- Add 15-minute rolling window for CPU, temperature, and fan speed metrics
- Implement D3.js graph with three colored lines (blue CPU %, red temp °C, green fan RPM)
- Store historical data in memory using VecDeque with automatic cleanup
- Add legend and responsive design for graph container
- Remove axis labels since metrics have different units (%, °C, RPM)
- Update WebSocket protocol to include metricsHistory array

🤖 Generated with [Claude Code](https://claude.ai/code)